### PR TITLE
Fix/export to workspace bugs

### DIFF
--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -327,6 +327,9 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 		return err
 	}
 
+	fmt.Println("gen3fuse sees contents: ")
+	fmt.Println(b)
+
 	manifestJSON := make([]manifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)
 

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -362,7 +362,7 @@ func readFile(path string) ([]byte, error) {
 }
 
 func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
-	FuseLog("Inside LoadDIDsFromManifest")
+	FuseLog(fmt.Sprintf("Inside LoadDIDsFromManifest, loading manifest from %v", manifestFilePath))
 	b, err := ioutil.ReadFile(manifestFilePath)
 	if err != nil {
 		return err

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -327,7 +327,9 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 		return err
 	}
 
-	fmt.Printf("The content of '%s' : \n%s\n", manifestFilePath, b)
+	s := string(b)
+	fmt.Println(s)
+	fmt.Printf("The content of '%s' : \n%s\n", manifestFilePath, s)
 
 	manifestJSON := make([]manifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -328,17 +328,11 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	}
 
 	s := string(b)
-	FuseLog(s)
-	FuseLog(fmt.Sprintf("The content of '%v' : \n%v\n", manifestFilePath, s))
-
 	sReplaceNone := strings.Replace(s, "None", "\"\"", -1)
 	sReplaceNoneAsBytes := []byte(sReplaceNone)
 
 	manifestJSON := make([]ManifestRecord, 0)
 	json.Unmarshal(sReplaceNoneAsBytes, &manifestJSON)
-
-	var structStr string = fmt.Sprintf("%#v", manifestJSON)
-	FuseLog("\nloading: " + structStr + "\n")
 
 	for i := 0; i < len(manifestJSON); i++ {
 		fs.DIDs = append(fs.DIDs, manifestJSON[i].ObjectId)

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -77,7 +77,7 @@ func NewGen3Fuse(ctx context.Context, gen3FuseConfig *Gen3FuseConfig, manifestFi
 
 	var didToFileInfo map[string]*IndexdResponse
 	if len(fs.DIDs) == 0 {
-		FuseLog("Warning: no DIDs were obtained from the manifest.")
+		FuseLog(fmt.Sprintf("Warning: no DIDs were obtained from the manifest %v.", manifestFilePath))
 	} else {
 		didToFileInfo, err = fs.GetFileNamesAndSizes()
 		if err != nil {

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"time"
-	"bufio"
-	"path/filepath"
 
 	"bytes"
 	"net/http"
@@ -322,45 +320,6 @@ func findChildInode(
 	return
 }
 
-func read(fd_r io.Reader) ([]byte, error) {
-	br := bufio.NewReader(fd_r)
-	var buf bytes.Buffer
-
-	for {
-		ba, isPrefix, err := br.ReadLine()
-
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-
-		buf.Write(ba)
-		if !isPrefix {
-			buf.WriteByte('\n')
-		}
-
-	}
-	return buf.Bytes(), nil
-}
-
-func readFile(path string) ([]byte, error) {
-	parentPath, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
-	pullPath := filepath.Join(parentPath, path)
-	file, err := os.Open(pullPath)
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close()
-	return read(file)
-}
-
 func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	FuseLog(fmt.Sprintf("Inside LoadDIDsFromManifest, loading manifest from %v", manifestFilePath))
 	b, err := ioutil.ReadFile(manifestFilePath)
@@ -368,11 +327,7 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 		return err
 	}
 
-	ba ,err := readFile(manifestFilePath)
-	if err != nil {
-		fmt.Println("Error: %s\n", err)
-	}
-	fmt.Printf("The content of '%s' : \n%s\n", manifestFilePath, ba)
+	fmt.Printf("The content of '%s' : \n%s\n", manifestFilePath, b)
 
 	manifestJSON := make([]manifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -330,6 +330,9 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	manifestJSON := make([]manifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)
 
+	var structStr string = fmt.Sprintf("%#v", manifestJSON)
+	FuseLog("\nloading: " + structStr + "\n")
+
 	for i := 0; i < len(manifestJSON); i++ {
 		fs.DIDs = append(fs.DIDs, manifestJSON[i].ObjectId)
 	}

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -328,8 +328,8 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	}
 
 	s := string(b)
-	fmt.Println(s)
-	fmt.Printf("The content of '%s' : \n%s\n", manifestFilePath, s)
+	FuseLog(s)
+	FuseLog(fmt.Sprintf("The content of '%v' : \n%v\n", manifestFilePath, s))
 
 	manifestJSON := make([]manifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -32,7 +32,7 @@ type Gen3Fuse struct {
 	gen3FuseConfig *Gen3FuseConfig
 }
 
-type manifestRecord struct {
+type ManifestRecord struct {
 	ObjectId  string `json:"object_id"`
 	SubjectId string `json:"subject_id"`
 	Uuid      string `json:"uuid"`
@@ -331,7 +331,7 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	FuseLog(s)
 	FuseLog(fmt.Sprintf("The content of '%v' : \n%v\n", manifestFilePath, s))
 
-	manifestJSON := make([]manifestRecord, 0)
+	manifestJSON := make([]ManifestRecord, 0)
 	json.Unmarshal(b, &manifestJSON)
 
 	var structStr string = fmt.Sprintf("%#v", manifestJSON)

--- a/internal/gen3fuse.go
+++ b/internal/gen3fuse.go
@@ -331,8 +331,11 @@ func (fs *Gen3Fuse) LoadDIDsFromManifest(manifestFilePath string) (err error) {
 	FuseLog(s)
 	FuseLog(fmt.Sprintf("The content of '%v' : \n%v\n", manifestFilePath, s))
 
+	sReplaceNone := strings.Replace(s, "None", "\"\"", -1)
+	sReplaceNoneAsBytes := []byte(sReplaceNone)
+
 	manifestJSON := make([]ManifestRecord, 0)
-	json.Unmarshal(b, &manifestJSON)
+	json.Unmarshal(sReplaceNoneAsBytes, &manifestJSON)
 
 	var structStr string = fmt.Sprintf("%#v", manifestJSON)
 	FuseLog("\nloading: " + structStr + "\n")
@@ -349,7 +352,6 @@ func (fs *Gen3Fuse) patchAttributes(attr *fuseops.InodeAttributes) {
 	attr.Mtime = now
 	attr.Crtime = now
 }
-
 func (fs *Gen3Fuse) StatFS(
 	ctx context.Context,
 	op *fuseops.StatFSOp) (err error) {

--- a/sidecarDockerrun.sh
+++ b/sidecarDockerrun.sh
@@ -24,7 +24,7 @@ while true; do
             resp=`curl https://$HOSTNAME/manifests/ -H "Authorization: bearer $TOKEN_JSON" 2>/dev/null`
         fi
         MANIFESTEXT=`echo $resp | jq --raw-output .manifests[-1].filename`
-        if [ $MANIFESTEXT = 'null' ]; then
+        if [ "$MANIFESTEXT" == "null" ]; then
             # user doens't have any manifest
             continue
         fi

--- a/sidecarDockerrun.sh
+++ b/sidecarDockerrun.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 cleanup() {
   killall gen3-fuse
   cd /data
@@ -31,7 +32,7 @@ while true; do
         if [ ! -d /data/$FILENAME ]; then
             echo mount manifest $MANIFESTEXT
             curl https://$HOSTNAME/manifests/file/$MANIFESTEXT -H "Authorization: Bearer $TOKEN_JSON"  > ~/manifest.json
-            gen3-fuse -config=~/fuse-config.yaml -manifest=~/manifest.json -mount-point=/data/$FILENAME -hostname=https://$HOSTNAME -wtsURL=http://workspace-token-service.$NAMESPACE >/proc/1/fd/1 2>/proc/1/fd/2
+            gen3-fuse -config=/fuse-config.yaml -manifest=/manifest.json -mount-point=/data/$FILENAME -hostname=https://$HOSTNAME -wtsURL=http://workspace-token-service.$NAMESPACE >/proc/1/fd/1 2>/proc/1/fd/2
         fi
     else
         OLDDIR=`df /data/manifest* |  grep manifest | cut -d'/' -f 3 | head -n 1`

--- a/sidecarDockerrun.sh
+++ b/sidecarDockerrun.sh
@@ -33,7 +33,7 @@ while true; do
             echo mount manifest $MANIFESTEXT
             curl https://$HOSTNAME/manifests/file/$MANIFESTEXT -H "Authorization: Bearer $TOKEN_JSON"  > /manifest.json
             manifest_contents=`cat /manifest.json`
-            echo 'manifest contents: $manifest_contents'
+            echo "manifest contents: $manifest_contents"
             gen3-fuse -config=/fuse-config.yaml -manifest=/manifest.json -mount-point=/data/$FILENAME -hostname=https://$HOSTNAME -wtsURL=http://workspace-token-service.$NAMESPACE >/proc/1/fd/1 2>/proc/1/fd/2
         fi
     else

--- a/sidecarDockerrun.sh
+++ b/sidecarDockerrun.sh
@@ -32,8 +32,6 @@ while true; do
         if [ ! -d /data/$FILENAME ]; then
             echo mount manifest $MANIFESTEXT
             curl https://$HOSTNAME/manifests/file/$MANIFESTEXT -H "Authorization: Bearer $TOKEN_JSON"  > /manifest.json
-            manifest_contents=`cat /manifest.json`
-            echo "manifest contents: $manifest_contents"
             gen3-fuse -config=/fuse-config.yaml -manifest=/manifest.json -mount-point=/data/$FILENAME -hostname=https://$HOSTNAME -wtsURL=http://workspace-token-service.$NAMESPACE >/proc/1/fd/1 2>/proc/1/fd/2
         fi
     else

--- a/sidecarDockerrun.sh
+++ b/sidecarDockerrun.sh
@@ -31,7 +31,9 @@ while true; do
         FILENAME=`echo $MANIFESTEXT | sed 's/\.[^.]*$//'`
         if [ ! -d /data/$FILENAME ]; then
             echo mount manifest $MANIFESTEXT
-            curl https://$HOSTNAME/manifests/file/$MANIFESTEXT -H "Authorization: Bearer $TOKEN_JSON"  > ~/manifest.json
+            curl https://$HOSTNAME/manifests/file/$MANIFESTEXT -H "Authorization: Bearer $TOKEN_JSON"  > /manifest.json
+            manifest_contents=`cat /manifest.json`
+            echo 'manifest contents: $manifest_contents'
             gen3-fuse -config=/fuse-config.yaml -manifest=/manifest.json -mount-point=/data/$FILENAME -hostname=https://$HOSTNAME -wtsURL=http://workspace-token-service.$NAMESPACE >/proc/1/fd/1 2>/proc/1/fd/2
         fi
     else


### PR DESCRIPTION
fixes a bug where un quoted "None" present in a manifest can result in a failed mount

for https://ctds-planx.atlassian.net/browse/PXP-4862

also cleans up some syntax problems

removed twiddles ~ from mount commands because they are run as root user in that container

deployed in qa-dcp
